### PR TITLE
Respect category limit

### DIFF
--- a/src/extensions/plg_osmap_com_content/com_content.php
+++ b/src/extensions/plg_osmap_com_content/com_content.php
@@ -212,7 +212,9 @@ class osmap_com_content
         $expand_categories = ( $expand_categories == 1
             || ( $expand_categories == 2 && $osmap->view == 'xml')
             || ( $expand_categories == 3 && $osmap->view == 'html')
-            || $osmap->view == 'navigator');
+            || $osmap->view == 'navigator'
+            || ($parent->params->get('maxLevel') != 0 && $parent->params->get('maxLevelcat') == -1)
+			);
         $params['expand_categories'] = $expand_categories;
 
         //----- Set expand_featured param


### PR DESCRIPTION
This PR solves https://github.com/OSTraining/OSMap/issues/100, i.e., if category levels set to "None" don't show them in sitemaps.

As said in the issue «for instance when you select to show only 2 subcategory levels and you have subcategory 5 levels, a more complex solution is needed.»