### PR TITLE
Creates Param to Debug XML Sitemap

### DIFF
--- a/src/admin/abstract.script.installer.php
+++ b/src/admin/abstract.script.installer.php
@@ -128,6 +128,7 @@ class AbstractOSMapInstallerScript extends AbstractScript
                 $attribs->compress_xml          = "1";
                 $attribs->beautify_xml          = "1";
                 $attribs->include_link          = "1";
+                $attribs->debug_osmap           = "0";
                 $attribs->news_publication_name = "";
 
                 $config = JFactory::getConfig();

--- a/src/admin/language/en-GB/en-GB.com_osmap.ini
+++ b/src/admin/language/en-GB/en-GB.com_osmap.ini
@@ -101,6 +101,9 @@ OSMAP_ATTRIBS_NEWS_POSTS_KEYWORDS_LABEL="Posts keywords"
 OSMAP_ATTRIBS_NEWS_POSTS_KEYWORDS_DESC="Comma separated list of keywords to describe your posts. Default to the post's category title."
 OSMAP_ATTRIBS_INCLUDE_LINK_LABEL="Link to author"
 OSMAP_ATTRIBS_INCLUDE_LINK_DESC="Include the link to OSMap's home at the bottom of the HTML site map."
+OSMAP_ATTRIBS_DEBUG_OSMAP_LABEL="Debug XML Sitemap"
+OSMAP_ATTRIBS_DUBUG_OSMAP_DESC="Errors will be shown in XML sitemap to help with debugging."
+
 
 ; Extension edit page
 OSMAP_PAGE_EDIT_EXTENSION="Edit Extension"

--- a/src/admin/models/forms/sitemap.xml
+++ b/src/admin/models/forms/sitemap.xml
@@ -301,6 +301,20 @@
                 <option
                     value="1">Yes</option>
             </field>
+            
+            <field
+                name="debug_osmap"
+                type="radio"
+                class="btn-group"
+                label="OSMAP_ATTRIBS_DEBUG_OSMAP_LABEL"
+                description="OSMAP_ATTRIBS_DUBUG_OSMAP_DESC"
+                labelclass="control-label"
+                default="0">
+                <option
+                    value="0">No</option>
+                <option
+                    value="1">Yes</option>
+            </field>
         </fieldset>
 
         <fieldset name="news" label="OSMAP_FIELDSET_NEWS_OPTIONS">

--- a/src/site/views/xml/tmpl/default.php
+++ b/src/site/views/xml/tmpl/default.php
@@ -14,14 +14,24 @@ $params = $this->item->params;
 
 $live_site = substr_replace(JURI::root(), "", -1, 1);
 
-header('Content-type: text/xml; charset=utf-8');
+if($this->item->params->get('debug_osmap') === "0")
+{
+    @ini_set('display_errors', 0);
+    header('Content-type: text/xml; charset=utf-8');
 
-echo '<?xml version="1.0" encoding="UTF-8"?>',"\n";
-if (($this->item->params->get('beautify_xml', 1) == 1) && !$this->displayer->isNews) {
-    $params  = '&amp;filter_showtitle='.JRequest::getBool('filter_showtitle',0);
-    $params .= '&amp;filter_showexcluded='.JRequest::getBool('filter_showexcluded',0);
-    $params .= (JRequest::getCmd('lang')?'&amp;lang='.JRequest::getCmd('lang'):'');
-    echo '<?xml-stylesheet type="text/xsl" href="'. $live_site.'/index.php?option=com_osmap&amp;view=xml&amp;layout=xsl&amp;tmpl=component&amp;id='.$this->item->id.($this->isImages?'&amp;images=1':'').$params.'"?>'."\n";
+    echo '<?xml version="1.0" encoding="UTF-8"?>',"\n";
+    if (($this->item->params->get('beautify_xml', 1) == 1) && !$this->displayer->isNews) {
+        $params  = '&amp;filter_showtitle='.JRequest::getBool('filter_showtitle',0);
+        $params .= '&amp;filter_showexcluded='.JRequest::getBool('filter_showexcluded',0);
+        $params .= (JRequest::getCmd('lang')?'&amp;lang='.JRequest::getCmd('lang'):'');
+        echo '<?xml-stylesheet type="text/xsl" href="'. $live_site.'/index.php?option=com_osmap&amp;view=xml&amp;layout=xsl&amp;tmpl=component&amp;id='.$this->item->id.($this->isImages?'&amp;images=1':'').$params.'"?>'."\n";
+    }
+}
+else
+{
+    @ini_set('display_errors', 1);
+    @ini_set('display_startup_errors', 1);
+    @error_reporting(E_ALL | E_STRICT);   
 }
 ?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"<?php echo ($this->displayer->isImages? ' xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"':''); ?><?php echo ($this->displayer->isNews? ' xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"':''); ?>>

--- a/src/site/views/xml/tmpl/default.php
+++ b/src/site/views/xml/tmpl/default.php
@@ -14,24 +14,23 @@ $params = $this->item->params;
 
 $live_site = substr_replace(JURI::root(), "", -1, 1);
 
-if($this->item->params->get('debug_osmap') === "0")
-{
+if ($this->item->params->get('debug_osmap', "0") == "0") {
     @ini_set('display_errors', 0);
     header('Content-type: text/xml; charset=utf-8');
-
-    echo '<?xml version="1.0" encoding="UTF-8"?>',"\n";
-    if (($this->item->params->get('beautify_xml', 1) == 1) && !$this->displayer->isNews) {
-        $params  = '&amp;filter_showtitle='.JRequest::getBool('filter_showtitle',0);
-        $params .= '&amp;filter_showexcluded='.JRequest::getBool('filter_showexcluded',0);
-        $params .= (JRequest::getCmd('lang')?'&amp;lang='.JRequest::getCmd('lang'):'');
-        echo '<?xml-stylesheet type="text/xsl" href="'. $live_site.'/index.php?option=com_osmap&amp;view=xml&amp;layout=xsl&amp;tmpl=component&amp;id='.$this->item->id.($this->isImages?'&amp;images=1':'').$params.'"?>'."\n";
-    }
 }
-else
-{
+else {
+    @error_reporting(E_ALL);
     @ini_set('display_errors', 1);
-    @ini_set('display_startup_errors', 1);
-    @error_reporting(E_ALL | E_STRICT);   
+    @ini_set('display_startup_errors', 1); 
+    header('Content-type: text/txt; charset=utf-8');
+}
+
+echo '<?xml version="1.0" encoding="UTF-8"?>',"\n";
+if (($this->item->params->get('beautify_xml', 1) == 1) && !$this->displayer->isNews) {
+    $params  = '&amp;filter_showtitle='.JRequest::getBool('filter_showtitle',0);
+    $params .= '&amp;filter_showexcluded='.JRequest::getBool('filter_showexcluded',0);
+    $params .= (JRequest::getCmd('lang')?'&amp;lang='.JRequest::getCmd('lang'):'');
+    echo '<?xml-stylesheet type="text/xsl" href="'. $live_site.'/index.php?option=com_osmap&amp;view=xml&amp;layout=xsl&amp;tmpl=component&amp;id='.$this->item->id.($this->isImages?'&amp;images=1':'').$params.'"?>'."\n";
 }
 ?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"<?php echo ($this->displayer->isImages? ' xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"':''); ?><?php echo ($this->displayer->isNews? ' xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"':''); ?>>

--- a/src/site/views/xml/view.html.php
+++ b/src/site/views/xml/view.html.php
@@ -60,9 +60,6 @@ class OSMapViewXml extends JViewLegacy
         $model = $this->getModel('Sitemap');
         $this->setModel($model);
 
-        // force to not display errors on XML sitemap
-        @ini_set('display_errors', 0);
-
         # Increase max execution time for XML sitemaps to make it work with very large sites
         @ini_set('max_execution_time', 300);
 


### PR DESCRIPTION
Resolves issue #54 in where it creates a param in OSMap > Options to be able to display errors in the xml file. 