### PR TITLE
Fix broken import link on installation

### DIFF
--- a/src/admin/views/installer/tmpl/default_custom.php
+++ b/src/admin/views/installer/tmpl/default_custom.php
@@ -113,7 +113,7 @@ $app->enqueueMessage(JText::sprintf('COM_OSMAP_INSTALLER_GOTOPLUGINS', $link), '
             });
         });
 
-    })(jQueryAlledia);
+    })(jQuery);
     </script>
 
 <?php endif; ?>


### PR DESCRIPTION
Alledia jquery file doesn't get loaded during installation, so jqueryAlledia is not defined and breaks installation js