### PR TITLE
Add Spanish es-ES language files for OSMap

### DIFF
--- a/src/admin/language/es-ES/es-ES.com_osmap.ini
+++ b/src/admin/language/es-ES/es-ES.com_osmap.ini
@@ -1,0 +1,130 @@
+; @package   OSMap
+; @contact   www.joomlashack.com, help@joomlashack.com
+; @copyright 2016-2026 Joomlashack.com. Todos los derechos reservados
+; @license   https://www.gnu.org/licenses/gpl.html GNU/GPL
+;
+; Este archivo es parte de OSMap.
+;
+; OSMap es software libre: puede redistribuirlo y/o modificarlo
+; bajo los términos de la Licencia Pública General GNU según lo publicado por
+; la Free Software Foundation, ya sea la versión 2 de la Licencia, o
+; (a su elección) cualquier versión posterior.
+;
+; OSMap se distribuye con la esperanza de que sea útil,
+; pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de
+; COMERCIABILIDAD o IDONEIDAD PARA UN PROPÓSITO PARTICULAR. Consulte la
+; Licencia Pública General GNU para más detalles.
+;
+; Debe haber recibido una copia de la Licencia Pública General GNU
+; junto con OSMap. Si no, consulte <https://www.gnu.org/licenses/>.
+;
+; Nota: Todos los archivos ini deben guardarse como UTF-8 - Sin BOM
+
+; Cadenas de instalación del componente
+COM_OSMAP="OSMap Free"
+COM_OSMAP_DESCRIPTION="OSMap - la forma más sencilla de crear un mapa del sitio en Joomla!"
+COM_OSMAP_CONFIGURATION="Opciones de OSMap"
+
+COM_OSMAP_ALWAYS="Siempre"
+
+COM_OSMAP_ATTRIBS_NEWS_PUBLICATION_NAME_DESC="Este es el nombre de la publicación de noticias. Debe coincidir exactamente con el nombre tal como aparece en sus artículos en news.google.com, omitiendo cualquier texto entre paréntesis al final. Por ejemplo, si el nombre aparece en Google News como &ldquo;The Example Times (subscription)&rdquo;, debe usar &ldquo;The Example Times&rdquo;."
+COM_OSMAP_ATTRIBS_NEWS_PUBLICATION_NAME_LABEL="Nombre de la publicación"
+
+COM_OSMAP_CHANGE_FREQUENCY_LABEL="Frecuencia de cambio"
+COM_OSMAP_COMMON_PUBLISHED_DESC="Establecer el estado de publicación"
+COM_OSMAP_COMMON_PUBLISHED_LABEL="Publicado"
+
+COM_OSMAP_DAILY="Diario"
+COM_OSMAP_EDIT_ITEMS="Editar elementos"
+COM_OSMAP_EMPTYSTATE_BUTTON_ADD="Crear el primer mapa del sitio"
+COM_OSMAP_EMPTYSTATE_CONTENT="OSMap genera automáticamente mapas del sitio basados en los menús del sitio. Estos pueden mostrarse en formato HTML para los usuarios o en formato XML para los servicios de indexación. También puede crear un mapa del sitio de contenido nuevo o un feed XML de noticias. Las imágenes del sitio también pueden incluirse en un mapa del sitio de imágenes."
+COM_OSMAP_EMPTYSTATE_TITLE="Aún no se han creado mapas del sitio."
+COM_OSMAP_ERROR_APPLICATION="Aplicación de Joomla desconocida '%s'"
+COM_OSMAP_FIELDSET_NEWS_OPTIONS="Mapa del sitio de noticias"
+COM_OSMAP_FIELDSET_SITEMAP_SETTINGS_LABEL="Configuración del mapa del sitio"
+
+COM_OSMAP_GRID_ID_ASC="ID ascendente"
+COM_OSMAP_GRID_ID_DESC="ID descendente"
+COM_OSMAP_GRID_NAME_ASC="Nombre ascendente"
+COM_OSMAP_GRID_NAME_DESC="Nombre descendente"
+COM_OSMAP_GRID_PUBLISHED_ASC="Publicado ascendente"
+COM_OSMAP_GRID_PUBLISHED_DESC="Publicado descendente"
+
+COM_OSMAP_HEADING_CHANGE_FREQ="Frecuencia de cambio"
+COM_OSMAP_HEADING_DEFAULT="Predeterminado"
+COM_OSMAP_HEADING_ID="ID"
+COM_OSMAP_HEADING_NAME="Nombre"
+COM_OSMAP_HEADING_NUM_LINKS="N.º de enlaces únicos"
+COM_OSMAP_HEADING_PRIORITY="Prioridad"
+COM_OSMAP_HEADING_SITEMAP_EDIT_LINKS="Editar enlaces"
+COM_OSMAP_HEADING_SITEMAP_LINKS="Enlaces del mapa del sitio"
+COM_OSMAP_HEADING_STATUS="Estado"
+COM_OSMAP_HEADING_TITLE="Título"
+COM_OSMAP_HEADING_URL="URL"
+
+COM_OSMAP_HOURLY="Cada hora"
+COM_OSMAP_HTML_LINK="HTML"
+COM_OSMAP_HTML_LINK_TOOLTIP="Ir a la versión HTML del mapa del sitio. Use esta URL para enviar el mapa del sitio a Google y otros motores de búsqueda."
+COM_OSMAP_HTML_SITEMAP_DESC="Mapa del sitio en formato HTML"
+COM_OSMAP_HTML_SITEMAP_LABEL="Mapa del sitio - HTML"
+
+COM_OSMAP_IMAGES_LINK="Imágenes"
+COM_OSMAP_IMAGES_LINK_TOOLTIP="Ir a la versión de imágenes del mapa del sitio. Use esta URL para enviar el mapa del sitio a Google y otros motores de búsqueda."
+COM_OSMAP_LOADING="Cargando... espere un momento"
+COM_OSMAP_MONTHLY="Mensual"
+
+COM_OSMAP_MSG_SITEMAP_FORCED_AS_DEFAULT="Mapa del sitio establecido como predeterminado, ya que no existe otro mapa del sitio predeterminado"
+COM_OSMAP_MSG_TASK_STOPPED_BY_PLUGIN="Ejecución cancelada por un plugin de OSMap"
+
+COM_OSMAP_NEVER="Nunca"
+COM_OSMAP_NEWS_LINK="Noticias"
+COM_OSMAP_NEWS_LINK_TOOLTIP="Ir a la versión de noticias del mapa del sitio. Use esta URL para enviar el mapa del sitio a Google News."
+COM_OSMAP_NO_ITEMS="No se encontraron elementos. Intente seleccionar un conjunto diferente de menús."
+COM_OSMAP_NO_MATCHING_RESULTS="Actualmente no tiene mapas del sitio. Haga clic en 'Nuevo' para crear uno."
+COM_OSMAP_NUMBER_OF_ITEMS_FOUND="Se encontraron %s elementos"
+
+COM_OSMAP_OPTION_SELECT_DEFAULT="- Seleccionar predeterminado -"
+COM_OSMAP_OPTION_SELECT_PUBLISHED="- Seleccionar estado -"
+COM_OSMAP_OPTION_SHOW_ITEM_UID_DESC="Si se habilita, muestra el UID de cada elemento al editar los elementos del mapa del sitio. El UID es el identificador único generado según el origen de cada elemento. Se utiliza para evitar mostrar elementos duplicados en el mapa del sitio."
+COM_OSMAP_OPTION_SHOW_ITEM_UID_LABEL="Mostrar UID del elemento"
+
+COM_OSMAP_PAGE_VIEW_SITEMAP_ADD="Nuevo mapa del sitio"
+COM_OSMAP_PAGE_VIEW_SITEMAP_EDIT="Editar mapa del sitio"
+COM_OSMAP_PAGE_VIEW_SITEMAP_ITEMS="Editar elementos del mapa del sitio"
+
+COM_OSMAP_PRIORITY_LABEL="Prioridad"
+COM_OSMAP_SELECTED_LABEL="Seleccionado"
+
+COM_OSMAP_SITEMAP="Mapa del sitio"
+COM_OSMAP_SITEMAP_DESCRIPTION_DESC="Descripción del mapa del sitio"
+COM_OSMAP_SITEMAP_DESCRIPTION_LABEL="Descripción"
+COM_OSMAP_SITEMAP_DETAILS="Detalles"
+COM_OSMAP_SITEMAP_IS_DEFAULT_DESC="Establecer como mapa del sitio predeterminado"
+COM_OSMAP_SITEMAP_IS_DEFAULT_LABEL="Mapa del sitio predeterminado"
+COM_OSMAP_SITEMAP_ITEMS="Elementos"
+COM_OSMAP_SITEMAP_N_ITEMS_PUBLISHED="%s elementos publicados correctamente"
+COM_OSMAP_SITEMAP_N_ITEMS_TRASHED="%s elementos enviados a la papelera correctamente"
+COM_OSMAP_SITEMAP_N_ITEMS_UNPUBLISHED="%s elementos despublicados correctamente"
+COM_OSMAP_SITEMAP_N_ITEMS_DELETED="%s elementos eliminados correctamente"
+COM_OSMAP_SITEMAP_NAME_DESC="Nombre del mapa del sitio"
+COM_OSMAP_SITEMAP_NAME_LABEL="Nombre"
+
+COM_OSMAP_SITEMAPITEMS_HEADING="Personalizar configuración: %s"
+
+COM_OSMAP_SUBMENU_EXTENSIONS="Extensiones"
+COM_OSMAP_SUBMENU_SITEMAPS="Mapas del sitio"
+COM_OSMAP_TITLE_LABEL="Título"
+
+COM_OSMAP_TOOLBAR_SET_DEFAULT="Establecer como predeterminado"
+COM_OSMAP_TOOLTIP_CLICK_TO_PUBLISH="Haga clic para publicar"
+COM_OSMAP_TOOLTIP_CLICK_TO_UNPUBLISH="Haga clic para despublicar"
+
+COM_OSMAP_UID="UID"
+COM_OSMAP_WEEKLY="Semanal"
+
+COM_OSMAP_XML_LINK="XML"
+COM_OSMAP_XML_LINK_TOOLTIP="Ir a la versión XML del mapa del sitio. Use esta URL para enviar el mapa del sitio a Google y otros motores de búsqueda."
+COM_OSMAP_XML_SITEMAP_DESC="Mapa del sitio en formato XML"
+COM_OSMAP_XML_SITEMAP_LABEL="Mapa del sitio - XML"
+
+COM_OSMAP_YEARLY="Anual"

--- a/src/admin/language/es-ES/es-ES.com_osmap.sys.ini
+++ b/src/admin/language/es-ES/es-ES.com_osmap.sys.ini
@@ -1,0 +1,87 @@
+; @package   OSMap
+; @contact   www.joomlashack.com, help@joomlashack.com
+; @copyright 2016-2026 Joomlashack.com. Todos los derechos reservados
+; @license   https://www.gnu.org/licenses/gpl.html GNU/GPL
+;
+; Este archivo es parte de OSMap.
+;
+; OSMap es software libre: puede redistribuirlo y/o modificarlo
+; bajo los términos de la Licencia Pública General GNU según lo publicado por
+; la Free Software Foundation, ya sea la versión 2 de la Licencia o,
+; a su elección, cualquier versión posterior.
+;
+; OSMap se distribuye con la esperanza de que sea útil,
+; pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de
+; COMERCIABILIDAD o IDONEIDAD PARA UN PROPÓSITO PARTICULAR. Consulte la
+; Licencia Pública General GNU para más detalles.
+;
+; Debe haber recibido una copia de la Licencia Pública General GNU
+; junto con OSMap. Si no, consulte <https://www.gnu.org/licenses/>.
+;
+; Nota: Todos los archivos ini deben guardarse como UTF-8 - Sin BOM
+
+COM_OSMAP="OSMap Free"
+COM_OSMAP_DESCRIPTION="OSMap - la forma más sencilla de crear un mapa del sitio en Joomla!"
+COM_OSMAP_CONFIGURATION="Opciones de OSMap"
+
+COM_OSMAP_CHANGE_SITEMAP="Seleccione un mapa del sitio de la lista"
+COM_OSMAP_CHANGE_SITEMAP_BUTTON="Cambiar"
+
+COM_OSMAP_FIELDSET_SITEMAP_SETTINGS_LABEL="Configuración del mapa del sitio"
+
+COM_OSMAP_INSTALLER_ERROR_MIGRATING_DATA="Se produjo un error al intentar actualizar los mapas del sitio: %s. Contacte con el equipo de soporte."
+COM_OSMAP_INSTALLER_GOTOPLUGINS="Ir a la página de %s para habilitar o deshabilitar los plugins de OSMap necesarios."
+COM_OSMAP_INSTALLER_IMPORT_XMAP_BUTTON="Importar datos de Xmap"
+COM_OSMAP_INSTALLER_IMPORT_XMAP_DESCRIPTION="Se ha detectado Xmap y sus datos. ¿Desea importarlos a OSMap?"
+COM_OSMAP_INSTALLER_IMPORT_XMAP_ERROR="No fue posible migrar los datos de Xmap correctamente. Se revirtieron todos los cambios."
+COM_OSMAP_INSTALLER_IMPORT_XMAP_SUCCESS="Los datos de Xmap se migraron correctamente. Ahora puede desinstalar el componente Xmap de forma segura, pero conserve los plugins."
+COM_OSMAP_INSTALLER_IMPORT_XMAP_TITLE="Datos de Xmap encontrados"
+COM_OSMAP_INSTALLER_IMPORT_XMAP_WIPE_WARNING="Atención: esta migración importará sus datos a OSMap, pero también eliminará cualquier dato existente en Xmap."
+COM_OSMAP_INSTALLER_IMPORTING="Importando..."
+COM_OSMAP_INSTALLER_PLUGINS_PAGE="página de plugins"
+COM_OSMAP_INSTALLER_WIPE_CONFIRMATION="¿Está seguro de que desea eliminar los datos actuales de Xmap? Los datos se importarán a OSMap."
+
+COM_OSMAP_MAX_MEMORY_CURRENT="Memoria: %s (%s)"
+COM_OSMAP_MAX_MEMORY_DESC="OSMap a veces necesita más memoria que la configurada. Esta opción permite que OSMap use más memoria, si es necesario, hasta el límite seleccionado."
+COM_OSMAP_MAX_MEMORY_LABEL="Aumentar memoria"
+
+COM_OSMAP_NEWS_PUBLICATION_NAME_DESC="Si se habilita, se establecerá el nombre de la publicación en el mapa del sitio de noticias."
+COM_OSMAP_NEWS_PUBLICATION_NAME_LABEL="Nombre de la publicación de noticias"
+
+COM_OSMAP_OPTION_128M="128M"
+COM_OSMAP_OPTION_1G="1G"
+COM_OSMAP_OPTION_256M="256M"
+COM_OSMAP_OPTION_512M="512M"
+COM_OSMAP_OPTION_ADD_STYLING_DESC="Si se habilita, aplica estilos al XML para facilitar su visualización en el navegador. No afecta a Google ni a otros bots."
+COM_OSMAP_OPTION_ADD_STYLING_LABEL="Añadir estilos"
+COM_OSMAP_OPTION_DEBUG_DESC="Si se habilita, mostrará el mapa del sitio como texto y permitirá ver advertencias o errores. Requiere activar la visualización de errores en la configuración global."
+COM_OSMAP_OPTION_DEBUG_LABEL="Depuración"
+COM_OSMAP_OPTION_IGNORE_DUPLICATED_UIDS_DESC="Si se habilita, el mapa del sitio XML ignorará automáticamente los elementos duplicados."
+COM_OSMAP_OPTION_IGNORE_DUPLICATED_UIDS_LABEL="Ignorar elementos duplicados"
+COM_OSMAP_OPTION_IGNORE_HIDDEN_MENUS_DESC="De forma predeterminada, se incluyen los menús marcados como ocultos. Seleccione 'Sí' para excluirlos del mapa del sitio."
+COM_OSMAP_OPTION_IGNORE_HIDDEN_MENUS_LABEL="Ignorar menús ocultos"
+COM_OSMAP_OPTION_NO_CHANGE="No ajustar"
+COM_OSMAP_OPTION_ONLY_HTML="Solo en el mapa del sitio HTML"
+COM_OSMAP_OPTION_SELECT_SITEMAP="Seleccione un mapa del sitio"
+COM_OSMAP_OPTION_SHOW_EXTERNAL_LINKS_DESC="Si se habilita, mostrará los enlaces externos en el mapa del sitio."
+COM_OSMAP_OPTION_SHOW_EXTERNAL_LINKS_LABEL="Mostrar enlaces externos"
+COM_OSMAP_OPTION_SHOW_MENU_TITLES_DESC="Si se habilita, mostrará el título de cada menú en el mapa del sitio."
+COM_OSMAP_OPTION_SHOW_MENU_TITLES_LABEL="Mostrar títulos de menú"
+COM_OSMAP_OPTION_UNLIMITED="Sin límite"
+COM_OSMAP_OPTION_USE_CSS_DESC="Si se habilita, añadirá el CSS básico a la vista. Esta opción es útil para corregir el estilo de la jerarquía de los elementos del mapa del sitio, que algunas plantillas pueden sobrescribir."
+COM_OSMAP_OPTION_USE_CSS_LABEL="Añadir CSS básico"
+
+COM_OSMAP_SHOW_SITEMAP_DESCRIPTION_DESC="Si se habilita, mostrará la descripción del mapa del sitio antes de los elementos."
+COM_OSMAP_SHOW_SITEMAP_DESCRIPTION_LABEL="Mostrar descripción del mapa del sitio"
+
+COM_OSMAP_SITEMAP_DESCRIPTION_DESC="Descripción del mapa del sitio."
+COM_OSMAP_SITEMAP_DESCRIPTION_LABEL="Descripción"
+COM_OSMAP_SITEMAP_HTML_VIEW_DEFAULT_DESC="Mostrar un mapa del sitio en formato HTML"
+COM_OSMAP_SITEMAP_HTML_VIEW_DEFAULT_TITLE="Mapa del sitio - HTML"
+COM_OSMAP_SITEMAP_XML_VIEW_DEFAULT_DESC="Mostrar un mapa del sitio en formato XML: XML predeterminado, imágenes y noticias"
+COM_OSMAP_SITEMAP_XML_VIEW_DEFAULT_TITLE="Mapa del sitio - XML (predeterminado, imágenes y noticias)"
+
+COM_OSMAP_SUBMENU_EXTENSIONS="Extensiones"
+COM_OSMAP_SUBMENU_SITEMAPS="Mapas del sitio"
+
+COM_OSMAP_TITLE="OSMap Free"

--- a/src/extensions/plg_osmap_demo/language/es-ES/es-ES.plg_osmap_demo.ini
+++ b/src/extensions/plg_osmap_demo/language/es-ES/es-ES.plg_osmap_demo.ini
@@ -1,0 +1,2 @@
+PLG_OSMAP_DEMO="OSMap - Demo"
+PLG_OSMAP_DEMO_DESCRIPTION="Plugin de demostración con una estructura mínima"

--- a/src/extensions/plg_osmap_demo/language/es-ES/es-ES.plg_osmap_demo.sys.ini
+++ b/src/extensions/plg_osmap_demo/language/es-ES/es-ES.plg_osmap_demo.sys.ini
@@ -1,0 +1,2 @@
+PLG_OSMAP_DEMO="OSMap - Demo"
+PLG_OSMAP_DEMO_DESCRIPTION="Plugin de demostración con una estructura mínima"

--- a/src/extensions/plg_osmap_joomla/language/es-ES/es-ES.plg_osmap_joomla.ini
+++ b/src/extensions/plg_osmap_joomla/language/es-ES/es-ES.plg_osmap_joomla.ini
@@ -1,0 +1,99 @@
+; @package   OSMap
+; @contact   www.joomlashack.com, help@joomlashack.com
+; @copyright 2016-2026 Joomlashack.com. Todos los derechos reservados
+; @license   https://www.gnu.org/licenses/gpl.html GNU/GPL
+;
+; Este archivo es parte de OSMap.
+;
+; OSMap es software libre: puede redistribuirlo y/o modificarlo
+; bajo los términos de la Licencia Pública General GNU publicada por
+; la Free Software Foundation, ya sea la versión 2 de la Licencia o,
+; a su elección, cualquier versión posterior.
+;
+; OSMap se distribuye con la esperanza de que sea útil,
+; pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de
+; COMERCIABILIDAD o IDONEIDAD PARA UN PROPÓSITO PARTICULAR. Consulte la
+; Licencia Pública General GNU para más detalles.
+;
+; Debe haber recibido una copia de la Licencia Pública General GNU
+; junto con OSMap. Si no, consulte <https://www.gnu.org/licenses/>.
+;
+; Nota: Todos los archivos ini deben guardarse como UTF-8 - Sin BOM
+
+PLG_OSMAP_JOOMLA="OSMap - Contenido de Joomla!"
+PLG_OSMAP_JOOMLA_PLUGIN_DESCRIPTION="Añade compatibilidad con artículos y categorías"
+
+COM_PLUGINS_BASIC_FIELDSET_LABEL="Configuración básica"
+COM_PLUGINS_NEWS_FIELDSET_LABEL="Configuración del mapa del sitio de noticias"
+COM_PLUGINS_XML_FIELDSET_LABEL="Configuración del mapa del sitio XML"
+
+JGLOBAL_FIELDSET_NEWS="Noticias"
+JGLOBAL_FIELDSET_XML="XML"
+
+PLG_OSMAP_JOOMLA_OPTION_ALL="Todos"
+PLG_OSMAP_JOOMLA_OPTION_ALWAYS="Siempre"
+PLG_OSMAP_JOOMLA_OPTION_ASC="ASC"
+PLG_OSMAP_JOOMLA_OPTION_CREATED="Fecha de creación"
+PLG_OSMAP_JOOMLA_OPTION_DAILY="Diario"
+PLG_OSMAP_JOOMLA_OPTION_DESC="DESC"
+PLG_OSMAP_JOOMLA_OPTION_HITS="Visitas"
+PLG_OSMAP_JOOMLA_OPTION_HOURLY="Cada hora"
+PLG_OSMAP_JOOMLA_OPTION_HTML_ONLY="Solo en el mapa del sitio HTML"
+PLG_OSMAP_JOOMLA_OPTION_MODIFIED="Fecha de modificación"
+PLG_OSMAP_JOOMLA_OPTION_MONTHLY="Mensual"
+PLG_OSMAP_JOOMLA_OPTION_NEVER="Nunca"
+PLG_OSMAP_JOOMLA_OPTION_ORDERING="Orden"
+PLG_OSMAP_JOOMLA_OPTION_PUBLISH="Fecha de publicación"
+PLG_OSMAP_JOOMLA_OPTION_TITLE="Título"
+PLG_OSMAP_JOOMLA_OPTION_USE_PARENT_MENU="Usar configuración del menú padre"
+PLG_OSMAP_JOOMLA_OPTION_WEEKLY="Semanal"
+PLG_OSMAP_JOOMLA_OPTION_XML_ONLY="Solo en el mapa del sitio XML"
+PLG_OSMAP_JOOMLA_OPTION_YEARLY="Anual"
+
+PLG_OSMAP_JOOMLA_SETTING_ADD_IMAGES_DESC="Si se habilita, se analizará el contenido del artículo para buscar imágenes y añadirlas al mapa del sitio. Solo es válido para el mapa del sitio XML."
+PLG_OSMAP_JOOMLA_SETTING_ADD_IMAGES_LABEL="¿Añadir imágenes?"
+PLG_OSMAP_JOOMLA_SETTING_ADD_PAGEBREAKS_DESC="Si se habilita, se incluirán las subpáginas del artículo en el mapa del sitio."
+PLG_OSMAP_JOOMLA_SETTING_ADD_PAGEBREAKS_LABEL="Añadir saltos de página"
+
+PLG_OSMAP_JOOMLA_SETTING_ART_CHANCE_FREQ="Frecuencia de cambio de los artículos"
+PLG_OSMAP_JOOMLA_SETTING_ART_CHANCE_FREQ_DESC="Defina la frecuencia de cambio de los artículos."
+PLG_OSMAP_JOOMLA_SETTING_ART_PRIORITY="Prioridad de los artículos"
+PLG_OSMAP_JOOMLA_SETTING_ART_PRIORITY_DESC="Defina la prioridad de los artículos."
+
+PLG_OSMAP_JOOMLA_SETTING_ARTICLE_ORDER_DESC="Especifique cómo ordenar los artículos."
+PLG_OSMAP_JOOMLA_SETTING_ARTICLE_ORDER_DIR_DESC="Especifique la dirección del orden."
+PLG_OSMAP_JOOMLA_SETTING_ARTICLE_ORDER_DIR_LABEL="Dirección del orden"
+PLG_OSMAP_JOOMLA_SETTING_ARTICLE_ORDER_LABEL="Orden de artículos"
+
+PLG_OSMAP_JOOMLA_SETTING_CAT_CHANCE_FREQ="Frecuencia de cambio de las categorías"
+PLG_OSMAP_JOOMLA_SETTING_CAT_CHANCE_FREQ_DESC="Defina la frecuencia de cambio de las categorías."
+PLG_OSMAP_JOOMLA_SETTING_CAT_PRIORITY="Prioridad de las categorías"
+PLG_OSMAP_JOOMLA_SETTING_CAT_PRIORITY_DESC="Defina la prioridad de las categorías."
+
+PLG_OSMAP_JOOMLA_SETTING_EXPAND_CATEGORIES="Expandir categorías"
+PLG_OSMAP_JOOMLA_SETTING_EXPAND_CATEGORIES_DESC="Si se habilita, OSMap incluirá los artículos dentro de cada enlace de categoría."
+PLG_OSMAP_JOOMLA_SETTING_EXPAND_FEATURED="Expandir destacados"
+PLG_OSMAP_JOOMLA_SETTING_EXPAND_FEATURED_DESC="Si se habilita, OSMap incluirá los artículos dentro de cada enlace de “Artículos destacados”."
+
+PLG_OSMAP_JOOMLA_SETTING_INCLUDE_ARCHIVED="Incluir archivados"
+PLG_OSMAP_JOOMLA_SETTING_INCLUDE_ARCHIVED_DESC="Seleccione cuándo deben incluirse los artículos archivados en el mapa del sitio."
+
+PLG_OSMAP_JOOMLA_SETTING_MAX_ART_AGE="Edad máxima del artículo (días)"
+PLG_OSMAP_JOOMLA_SETTING_MAX_ART_AGE_DESC="Número máximo de días que puede tener un artículo para incluirse en el mapa del sitio (0 sin límite)."
+PLG_OSMAP_JOOMLA_SETTING_MAX_ART_CAT="Máximo de artículos por categoría"
+PLG_OSMAP_JOOMLA_SETTING_MAX_ART_CAT_DESC="Número máximo de artículos por categoría que se incluirán en el mapa del sitio (0 sin límite)."
+
+PLG_OSMAP_JOOMLA_SETTING_MAX_CATEG_LEVEL_LABEL="Niveles máximos de subcategorías"
+
+PLG_OSMAP_JOOMLA_SETTING_NEWS_KEYWORDS_CATTITLE="Título de la categoría"
+PLG_OSMAP_JOOMLA_SETTING_NEWS_KEYWORDS_DESC="¿Qué palabras clave deben utilizarse en el mapa del sitio de Google News?"
+PLG_OSMAP_JOOMLA_SETTING_NEWS_KEYWORDS_LABEL="Palabras clave"
+PLG_OSMAP_JOOMLA_SETTING_NEWS_KEYWORDS_METAKEYS="Palabras clave meta del artículo"
+PLG_OSMAP_JOOMLA_SETTING_NEWS_KEYWORDS_METAKEYS_CATTITLE="Palabras clave meta del artículo + título de la categoría"
+PLG_OSMAP_JOOMLA_SETTING_NEWS_KEYWORDS_NONE="Ninguna"
+
+PLG_OSMAP_JOOMLA_SETTING_PREPARE_CONTENT_DESC="Permite preparar el contenido mediante los plugins de contenido de Joomla!"
+PLG_OSMAP_JOOMLA_SETTING_PREPARE_CONTENT_LABEL="Preparar contenido"
+
+PLG_OSMAP_JOOMLA_SETTING_SHOW_UNAUTH_LINKS="Mostrar enlaces no autorizados"
+PLG_OSMAP_JOOMLA_SETTING_SHOW_UNAUTH_LINKS_DESC="Si se habilita, se mostrarán enlaces a contenido restringido aunque el usuario no haya iniciado sesión. El usuario deberá iniciar sesión para ver el contenido completo."

--- a/src/extensions/plg_osmap_joomla/language/es-ES/es-ES.plg_osmap_joomla.sys.ini
+++ b/src/extensions/plg_osmap_joomla/language/es-ES/es-ES.plg_osmap_joomla.sys.ini
@@ -1,0 +1,25 @@
+; @package   OSMap
+; @contact   www.joomlashack.com, help@joomlashack.com
+; @copyright 2016-2026 Joomlashack.com. Todos los derechos reservados
+; @license   https://www.gnu.org/licenses/gpl.html GNU/GPL
+;
+; Este archivo es parte de OSMap.
+;
+; OSMap es software libre: puede redistribuirlo y/o modificarlo
+; bajo los términos de la Licencia Pública General GNU publicada por
+; la Free Software Foundation, ya sea la versión 2 de la Licencia o,
+; a su elección, cualquier versión posterior.
+;
+; OSMap se distribuye con la esperanza de que sea útil,
+; pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de
+; COMERCIABILIDAD o IDONEIDAD PARA UN PROPÓSITO PARTICULAR. Consulte la
+; Licencia Pública General GNU para más detalles.
+;
+; Debe haber recibido una copia de la Licencia Pública General GNU
+; junto con OSMap. Si no, consulte <https://www.gnu.org/licenses/>.
+;
+; Nota: Todos los archivos ini deben guardarse como UTF-8 - Sin BOM
+
+PLG_OSMAP_JOOMLA="Contenido - OSMap Free"
+
+PLG_OSMAP_JOOMLA_PLUGIN_DESCRIPTION="Añade compatibilidad con artículos y categorías"

--- a/src/site/language/es-ES/es-ES.com_osmap.ini
+++ b/src/site/language/es-ES/es-ES.com_osmap.ini
@@ -1,0 +1,94 @@
+; @package   OSMap
+; @package   OSMap
+; @contact   www.joomlashack.com, help@joomlashack.com
+; @copyright 2007-2014 XMap - Joomla! Vargas - Guillermo Vargas. Todos los derechos reservados.
+; @copyright 2016-2025 Joomlashack.com. Todos los derechos reservados.
+; @license   https://www.gnu.org/licenses/gpl.html GNU/GPL
+;
+; Este archivo es parte de OSMap.
+;
+; OSMap es software libre: puede redistribuirlo y/o modificarlo
+; bajo los términos de la Licencia Pública General GNU publicada por
+; la Free Software Foundation, ya sea la versión 2 de la Licencia o,
+; a su elección, cualquier versión posterior.
+;
+; OSMap se distribuye con la esperanza de que sea útil,
+; pero SIN NINGUNA GARANTÍA; incluso sin la garantía implícita de
+; COMERCIABILIDAD o IDONEIDAD PARA UN PROPÓSITO PARTICULAR. Consulte la
+; Licencia Pública General GNU para más detalles.
+;
+; Debe haber recibido una copia de la Licencia Pública General GNU
+; junto con OSMap. Si no, consulte <https://www.gnu.org/licenses/>.
+;
+; Nota: Todos los archivos ini deben guardarse como UTF-8 - Sin BOM
+
+COM_OSMAP_ADAPTER_CLASS="Clase del adaptador"
+
+COM_OSMAP_ADMIN_NOTE_DUPLICATED="- Duplica otro elemento mostrado (compare el UID)."
+COM_OSMAP_ADMIN_NOTE_DUPLICATED_IGNORED="- Duplica otro elemento mostrado (compare el UID)."
+COM_OSMAP_ADMIN_NOTE_DUPLICATED_URL_IGNORED="Duplica otro elemento mostrado, según la URL"
+COM_OSMAP_ADMIN_NOTE_IGNORED_EXTERNAL="- Enlace externo. El mapa del sitio no lo mostrará."
+COM_OSMAP_ADMIN_NOTE_IGNORED_EXTERNAL_HTML="- Enlace externo. Si está publicado, solo el mapa del sitio HTML lo mostrará."
+COM_OSMAP_ADMIN_NOTE_INVISIBLE_FOR_ROBOTS="Establecido como invisible para los robots. No se mostrará en el mapa del sitio XML."
+COM_OSMAP_ADMIN_NOTE_PARENT_INVISIBLE_FOR_ROBOTS="El elemento superior está marcado como invisible para los robots. No se mostrará en el mapa del sitio XML."
+COM_OSMAP_ADMIN_NOTE_PARENT_UNPUBLISHED="- Despublicado porque el elemento superior está despublicado."
+COM_OSMAP_ADMIN_NOTE_VISIBLE_HTML_ONLY="- Establecido como visible solo para el mapa del sitio HTML."
+COM_OSMAP_ADMIN_NOTE_VISIBLE_XML_ONLY="- Establecido como visible solo para el mapa del sitio XML."
+COM_OSMAP_ADMIN_NOTES="Notas"
+
+COM_OSMAP_ALWAYS="Siempre"
+
+COM_OSMAP_CHANGE_FREQ="Frecuencia de cambio"
+COM_OSMAP_DAILY="Diario"
+
+COM_OSMAP_DEBUG_ALERT="El modo de depuración está habilitado para este menú. Si desea ver nuevamente el mapa del sitio en HTML normal, desactive la depuración en los parámetros del menú."
+COM_OSMAP_DEBUG_ALERT_TITLE="Modo de depuración"
+
+COM_OSMAP_DOCUMENTATION="documentación"
+COM_OSMAP_DUPLICATE="Elemento duplicado"
+COM_OSMAP_FULL_LINK="Enlace completo"
+
+COM_OSMAP_HEADING_CHANGE_FREQ="Frecuencia de cambio"
+COM_OSMAP_HEADING_PRIORITY="Prioridad"
+COM_OSMAP_HEADING_PUBLICATION_DATE="Fecha de publicación"
+COM_OSMAP_HEADING_STATUS="Estado"
+COM_OSMAP_HEADING_TITLE="Título"
+COM_OSMAP_HEADING_URL="URL"
+
+COM_OSMAP_HOURLY="Cada hora"
+COM_OSMAP_IMAGES="imágenes"
+COM_OSMAP_INSTRUCTIONS="Para editar su mapa del sitio, utilice la interfaz de administración. Consulte la "
+
+COM_OSMAP_LEVEL="Nivel"
+COM_OSMAP_LINK="Enlace"
+
+COM_OSMAP_MENUTYPE="Tipo de menú"
+COM_OSMAP_MODIFICATION_DATE="Fecha de última modificación"
+COM_OSMAP_MODIFIED="Modificado"
+COM_OSMAP_MONTHLY="Mensual"
+
+COM_OSMAP_MSG_SITEMAP_IS_UNPUBLISHED="Lo sentimos, este mapa del sitio no es accesible."
+COM_OSMAP_MSG_TASK_STOPPED_BY_PLUGIN="Ejecución cancelada por un plugin de OSMap"
+
+COM_OSMAP_NEVER="Nunca"
+COM_OSMAP_NO_ITEMS="No se encontraron elementos. Intente seleccionar un conjunto diferente de menús."
+COM_OSMAP_NUMBER_OF_ITEMS_FOUND="Se encontraron %s elementos"
+COM_OSMAP_NUMBER_OF_URLS="Total de URL"
+
+COM_OSMAP_PRIORITY_LABEL="Prioridad"
+COM_OSMAP_RAW_LINK="Enlace sin procesar"
+
+COM_OSMAP_SITEMAP="Mapa del sitio"
+COM_OSMAP_SITEMAP_ID="ID del mapa del sitio"
+COM_OSMAP_SITEMAP_ITEMS_COUNT="Cantidad de elementos"
+COM_OSMAP_SITEMAP_NOT_FOUND="Mapa del sitio no encontrado"
+
+COM_OSMAP_TOOLTIP_CLICK_TO_PUBLISH="Haga clic para publicar"
+COM_OSMAP_TOOLTIP_CLICK_TO_UNPUBLISH="Haga clic para despublicar"
+
+COM_OSMAP_UID="UID"
+COM_OSMAP_URL="URL"
+COM_OSMAP_VISIBLE_FOR_ROBOTS="Visible para los robots"
+COM_OSMAP_WARNING_OOM="OSMap (%s) se quedó sin memoria. Informe al administrador del sitio que será necesario reconfigurar el servidor."
+COM_OSMAP_WEEKLY="Semanal"
+COM_OSMAP_YEARLY="Anual"


### PR DESCRIPTION
This pull request adds Spanish (es-ES) language files for OSMap Free.

The translation includes the administrator, site, and OSMap plugin language files available in the current repository structure.

The es-ES files were reviewed for:

* Key alignment with the original en-GB files
* Joomla! terminology consistency
* Spanish grammar, spelling, syntax, and semantics
* Plugin naming conventions used in Joomla!

Language: Spanish (Spain) / es-ES
OSMap version: 5.1.6
Translator: Andrés Restrepo / Alamarte.com
