### PR TITLE
Improve duplicate item admin note language strings

### DIFF
--- a/src/site/language/en-GB/en-GB.com_osmap.ini
+++ b/src/site/language/en-GB/en-GB.com_osmap.ini
@@ -23,6 +23,7 @@
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 COM_OSMAP_ADAPTER_CLASS = "Adapter Class"
+
 COM_OSMAP_ADMIN_NOTE_DUPLICATED = "- Duplicates another displayed item. Duplicate filtering is disabled, so this item will still be included in the sitemap."
 COM_OSMAP_ADMIN_NOTE_DUPLICATED_IGNORED = "- Duplicates another displayed item and is excluded because duplicate filtering is enabled."
 COM_OSMAP_ADMIN_NOTE_DUPLICATED_URL_IGNORED = "Duplicates another displayed item, based on the URL"

--- a/src/site/language/en-GB/en-GB.com_osmap.ini
+++ b/src/site/language/en-GB/en-GB.com_osmap.ini
@@ -23,9 +23,8 @@
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 
 COM_OSMAP_ADAPTER_CLASS = "Adapter Class"
-
-COM_OSMAP_ADMIN_NOTE_DUPLICATED = "- Duplicates another displayed item (compare the UID)."
-COM_OSMAP_ADMIN_NOTE_DUPLICATED_IGNORED = "- Duplicates another displayed item (compare the UID)."
+COM_OSMAP_ADMIN_NOTE_DUPLICATED = "- Duplicates another displayed item. Duplicate filtering is disabled, so this item will still be included in the sitemap."
+COM_OSMAP_ADMIN_NOTE_DUPLICATED_IGNORED = "- Duplicates another displayed item and is excluded because duplicate filtering is enabled."
 COM_OSMAP_ADMIN_NOTE_DUPLICATED_URL_IGNORED = "Duplicates another displayed item, based on the URL"
 COM_OSMAP_ADMIN_NOTE_IGNORED_EXTERNAL = "- External link. The sitemap will not display it."
 COM_OSMAP_ADMIN_NOTE_IGNORED_EXTERNAL_HTML = "- External link. If published, only the HTML sitemap will display it."


### PR DESCRIPTION
Currently, OSMap uses two separate language strings for duplicate items:

COM_OSMAP_ADMIN_NOTE_DUPLICATED
COM_OSMAP_ADMIN_NOTE_DUPLICATED_IGNORED

Although they are used in different situations, both strings currently contain exactly the same text:

- Duplicates another displayed item (compare the UID).

This makes it impossible for administrators to tell whether the duplicate item is simply being reported or is actually being excluded from the sitemap because Ignore Duplicated Items is enabled.

This PR updates the language strings to reflect the actual behaviour.