### PR TITLE
Fix sitemap selection with apostrophes in names (for J3)

### DIFF
--- a/src/admin/views/sitemaps/tmpl/modal.j3.php
+++ b/src/admin/views/sitemaps/tmpl/modal.j3.php
@@ -115,10 +115,22 @@ $formAction = [
                                 [
                                     'style'   => 'cursor: pointer;',
                                     'onclick' => sprintf(
-                                        "if (window.parent) window.parent.%s('%s', '%s');",
+                                        'if (window.parent) window.parent.%s(%s, %s);',
                                         $function,
-                                        $item->id,
-                                        $this->escape($item->name)
+                                        json_encode(
+                                            (string) $item->id,
+                                            JSON_HEX_TAG
+                                            | JSON_HEX_AMP
+                                            | JSON_HEX_APOS
+                                            | JSON_HEX_QUOT
+                                        ),
+                                        json_encode(
+                                            $item->name,
+                                            JSON_HEX_TAG
+                                            | JSON_HEX_AMP
+                                            | JSON_HEX_APOS
+                                            | JSON_HEX_QUOT
+                                        )
                                     )
                                 ]
                             );

--- a/src/admin/views/sitemaps/tmpl/modal.j3.php
+++ b/src/admin/views/sitemaps/tmpl/modal.j3.php
@@ -115,18 +115,12 @@ $formAction = [
                                 [
                                     'style'   => 'cursor: pointer;',
 
-                                    // Encode the sitemap name as a JavaScript string to safely handle quotes and other special characters.
+                                    // Encode the sitemap name as a valid JavaScript string.
                                     'onclick' => sprintf(
                                         "if (window.parent) window.parent.%s('%s', %s);",
                                         $function,
                                         $item->id,
-                                        json_encode(
-                                            $item->name,
-                                            JSON_HEX_TAG
-                                            | JSON_HEX_AMP
-                                            | JSON_HEX_APOS
-                                            | JSON_HEX_QUOT
-                                        )
+                                        json_encode($item->name)
                                     )
                                 ]
                             );

--- a/src/admin/views/sitemaps/tmpl/modal.j3.php
+++ b/src/admin/views/sitemaps/tmpl/modal.j3.php
@@ -114,16 +114,12 @@ $formAction = [
                                 $this->escape($item->name),
                                 [
                                     'style'   => 'cursor: pointer;',
+
+                                    // Encode the sitemap name as a JavaScript string to safely handle quotes and other special characters.
                                     'onclick' => sprintf(
-                                        'if (window.parent) window.parent.%s(%s, %s);',
+                                        "if (window.parent) window.parent.%s('%s', %s);",
                                         $function,
-                                        json_encode(
-                                            (string) $item->id,
-                                            JSON_HEX_TAG
-                                            | JSON_HEX_AMP
-                                            | JSON_HEX_APOS
-                                            | JSON_HEX_QUOT
-                                        ),
+                                        $item->id,
                                         json_encode(
                                             $item->name,
                                             JSON_HEX_TAG

--- a/src/admin/views/sitemaps/tmpl/modal.php
+++ b/src/admin/views/sitemaps/tmpl/modal.php
@@ -121,10 +121,22 @@ $formAction = [
                                         [
                                             'style'   => 'cursor: pointer;',
                                             'onclick' => sprintf(
-                                                "if (window.parent) window.parent.%s('%s', '%s');",
+                                                'if (window.parent) window.parent.%s(%s, %s);',
                                                 $function,
-                                                $item->id,
-                                                $this->escape($item->name)
+                                                json_encode(
+                                                    (string) $item->id,
+                                                    JSON_HEX_TAG
+                                                    | JSON_HEX_AMP
+                                                    | JSON_HEX_APOS
+                                                    | JSON_HEX_QUOT
+                                                ),
+                                                json_encode(
+                                                    $item->name,
+                                                    JSON_HEX_TAG
+                                                    | JSON_HEX_AMP
+                                                    | JSON_HEX_APOS
+                                                    | JSON_HEX_QUOT
+                                                )
                                             )
                                         ]
                                     );

--- a/src/admin/views/sitemaps/tmpl/modal.php
+++ b/src/admin/views/sitemaps/tmpl/modal.php
@@ -121,18 +121,12 @@ $formAction = [
                                         [
                                             'style'   => 'cursor: pointer;',
 
-                                            // Encode the sitemap name as a JavaScript string to safely handle quotes and other special characters.
+                                            // Encode the sitemap name as a valid JavaScript string.
                                             'onclick' => sprintf(
                                                 "if (window.parent) window.parent.%s('%s', %s);",
                                                 $function,
                                                 $item->id,
-                                                json_encode(
-                                                    $item->name,
-                                                    JSON_HEX_TAG
-                                                    | JSON_HEX_AMP
-                                                    | JSON_HEX_APOS
-                                                    | JSON_HEX_QUOT
-                                                )
+                                                json_encode($item->name)
                                             )
                                         ]
                                     );

--- a/src/admin/views/sitemaps/tmpl/modal.php
+++ b/src/admin/views/sitemaps/tmpl/modal.php
@@ -120,16 +120,12 @@ $formAction = [
                                         $this->escape($item->name),
                                         [
                                             'style'   => 'cursor: pointer;',
+
+                                            // Encode the sitemap name as a JavaScript string to safely handle quotes and other special characters.
                                             'onclick' => sprintf(
-                                                'if (window.parent) window.parent.%s(%s, %s);',
+                                                "if (window.parent) window.parent.%s('%s', %s);",
                                                 $function,
-                                                json_encode(
-                                                    (string) $item->id,
-                                                    JSON_HEX_TAG
-                                                    | JSON_HEX_AMP
-                                                    | JSON_HEX_APOS
-                                                    | JSON_HEX_QUOT
-                                                ),
+                                                $item->id,
                                                 json_encode(
                                                     $item->name,
                                                     JSON_HEX_TAG


### PR DESCRIPTION
Properly escape sitemap names when passing them to the JavaScript selection function. This prevents sitemap names containing apostrophes, quotes, or other special characters from causing JavaScript syntax errors.